### PR TITLE
Fix model select argument of gfpgan

### DIFF
--- a/face_restoration/gfpgan/gfpgan.py
+++ b/face_restoration/gfpgan/gfpgan.py
@@ -63,7 +63,8 @@ parser.add_argument(
 parser.add_argument(
     '-m', '--model_name',
     default='v1.3',
-    help=['v1.3', 'v1.4']
+    choices=['v1.3', 'v1.4'],
+    help="Select model version"
 )
 parser.add_argument(
     '--onnx',


### PR DESCRIPTION
gfpgan のモデル指定オプションの help を修正しました。

以前から ArgumentParser の `help=` に文字列以外を渡すとエラーになるようでしたが、python 3.13 まではヘルプ表示時にエラーとなり、python 3.14 からは `add_argument()` の時点でエラーになるように挙動が変わったようです。