### PR TITLE
Download reference audio from ailia-models storage instead of GitHub

### DIFF
--- a/audio_processing/gpt-sovits-v2-pro/example_ailia_voice.py
+++ b/audio_processing/gpt-sovits-v2-pro/example_ailia_voice.py
@@ -19,7 +19,7 @@ ref_text = "水をマレーシアから買わなくてはならない。"
 ref_file_path = "reference_audio_girl.wav"
 if not os.path.exists(ref_file_path):
 	urllib.request.urlretrieve(
-		"https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/audio_processing/gpt-sovits/reference_audio_captured_by_ax.wav",
+		"http://storage.googleapis.com/ailia-models/misc/reference_audio_girl.wav",
 		"reference_audio_girl.wav"
 	)
 audio_waveform, sampling_rate = librosa.load(ref_file_path, mono=True)

--- a/audio_processing/gpt-sovits/example_ailia_voice.py
+++ b/audio_processing/gpt-sovits/example_ailia_voice.py
@@ -19,7 +19,7 @@ ref_text = "水をマレーシアから買わなくてはならない。"
 ref_file_path = "reference_audio_girl.wav"
 if not os.path.exists(ref_file_path):
 	urllib.request.urlretrieve(
-		"https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/audio_processing/gpt-sovits/reference_audio_captured_by_ax.wav",
+		"http://storage.googleapis.com/ailia-models/misc/reference_audio_girl.wav",
 		"reference_audio_girl.wav"
 	)
 audio_waveform, sampling_rate = librosa.load(ref_file_path, mono=True)


### PR DESCRIPTION
GitHub is unreachable in environments without SSL. Serve the same reference audio over plain HTTP from storage.googleapis.com.