### PR TITLE
Update sadtalker for numpy 2

### DIFF
--- a/generative_adversarial_networks/sadtalker/preprocess/face3d_utils.py
+++ b/generative_adversarial_networks/sadtalker/preprocess/face3d_utils.py
@@ -26,7 +26,7 @@ def POS(xp, x):
 
     b = np.reshape(xp.transpose(), [2*npts, 1])
 
-    k, _, _, _ = np.linalg.lstsq(A, b)
+    k, _, _, _ = np.linalg.lstsq(A, b, rcond=-1) # default of numpy 1.x
 
     R1 = k[0:3]
     R2 = k[4:7]

--- a/generative_adversarial_networks/sadtalker/preprocess/face3d_utils.py
+++ b/generative_adversarial_networks/sadtalker/preprocess/face3d_utils.py
@@ -33,7 +33,7 @@ def POS(xp, x):
     sTx = k[3]
     sTy = k[7]
     s = (np.linalg.norm(R1) + np.linalg.norm(R2))/2
-    t = np.stack([sTx, sTy], axis=0)
+    t = np.stack([sTx, sTy], axis=0).reshape(-1)
 
     return t, s
     

--- a/generative_adversarial_networks/sadtalker/preprocess/face3d_utils.py
+++ b/generative_adversarial_networks/sadtalker/preprocess/face3d_utils.py
@@ -8,8 +8,9 @@ import cv2
 import os
 from skimage import transform as trans
 import warnings
-warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning) 
-warnings.filterwarnings("ignore", category=FutureWarning) 
+if hasattr(np, "VisibleDeprecationWarning"):
+    warnings.filterwarnings("ignore", category=np.VisibleDeprecationWarning)
+warnings.filterwarnings("ignore", category=FutureWarning)
 
 
 # calculating least square problem for image alignment

--- a/generative_adversarial_networks/sadtalker/preprocess/preprocess.py
+++ b/generative_adversarial_networks/sadtalker/preprocess/preprocess.py
@@ -126,7 +126,7 @@ class CropAndExtract():
 
                 trans_params, im1, lm1, _ = align_img(frame, lm1, self.lm3d_std)
  
-                trans_params = np.array([float(item) for item in np.hsplit(trans_params, 5)]).astype(np.float32)
+                trans_params = np.asarray(trans_params, dtype=np.float32).reshape(-1)
                 im_np = np.transpose(np.array(im1, dtype=np.float32) / 255.0, (2, 0, 1))[np.newaxis, ...]
                 
                 if self.use_onnx:


### PR DESCRIPTION
sadtalker が numpy2 環境で推論エラーになる問題に対処する pull request です。

- numpy 2 系に np.VisibleDeprecationWarning がなく、エラーになるので hasattr でチェックするようにしました
- numpy2 系でスカラを期待する箇所に1要素のサイズでも配列を渡すとエラーになる挙動に引っ掛かる部分を修正しました

また、エラーの原因にはなっていませんが、np.linalg.lstsq() の rcond 引数のデフォルト値が numpy 1, 2 系で変わったようなので numpy 1 に合わせました。