### PR TITLE
Update g2p_en

### DIFF
--- a/natural_language_processing/g2p_en/averaged_perceptron.py
+++ b/natural_language_processing/g2p_en/averaged_perceptron.py
@@ -1,5 +1,16 @@
-from nltk.data import load
+import pickle
 from collections import defaultdict
+
+# python 2 系の __builtin__.set を持った pickle をロードする互換 unpickler
+class CompatUnpickler(pickle.Unpickler):
+    ALLOWED = [
+        ("__builtin__", "set"),
+    ]
+
+    def find_class(self, module, name):
+        if (module, name) in self.ALLOWED:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(f"forbidden global: {module}.{name}")
 
 EXPORT_TO_TEXT = False
 IMPORT_FROM_TEXT = False
@@ -29,7 +40,8 @@ class AveragedPerceptron:
 model = AveragedPerceptron()
 
 def export_to_text():
-    weights, tagdict, classes = load("averaged_perceptron_tagger.pickle")
+    with open("averaged_perceptron_tagger.pickle", "rb") as f:
+        weights, tagdict, classes = CompatUnpickler(f).load()
     f = open("averaged_perceptron_tagger_weights.txt", "w")
     for feat in weights.keys():
         feat_weights = weights[feat]
@@ -83,7 +95,8 @@ if EXPORT_TO_TEXT:
 if IMPORT_FROM_TEXT:
     model.weights, tagdict, model.classes = import_from_text()
 else:
-    model.weights, tagdict, model.classes = load("averaged_perceptron_tagger.pickle")
+    with open("averaged_perceptron_tagger.pickle", "rb") as f:
+        model.weights, tagdict, model.classes = CompatUnpickler(f).load()
 
 START = ["-START-", "-START2-"]
 END = ["-END-", "-END2-"]

--- a/natural_language_processing/g2p_en/g2p_en.py
+++ b/natural_language_processing/g2p_en/g2p_en.py
@@ -5,7 +5,6 @@ from logging import getLogger
 
 import numpy as np
 
-import codecs
 import re
 import os
 import unicodedata
@@ -66,7 +65,7 @@ dirname = os.path.dirname(__file__)
 def construct_homograph_dictionary():
     f = os.path.join(dirname,'homographs.en')
     homograph2features = dict()
-    for line in codecs.open(f, 'r', 'utf8').read().splitlines():
+    for line in open(f, 'r', encoding='utf-8').read().splitlines():
         if line.startswith("#"): continue # comment
         headword, pron1, pron2, pos1 = line.strip().split("|")
         homograph2features[headword.lower()] = (pron1.split(), pron2.split(), pos1)
@@ -75,7 +74,7 @@ def construct_homograph_dictionary():
 def construct_cmu_dictionary():
     f = os.path.join(dirname,'cmudict')
     cmudict = dict()
-    for line in codecs.open(f, 'r', 'utf8').read().splitlines():
+    for line in open(f, 'r', encoding='utf-8').read().splitlines():
         if line.startswith("#"): continue # comment
         lists = line.strip().split(" ")
         headword = lists[0]

--- a/natural_language_processing/g2p_en/g2p_en.py
+++ b/natural_language_processing/g2p_en/g2p_en.py
@@ -155,7 +155,7 @@ class G2p(object):
         text = ''.join(char for char in unicodedata.normalize('NFD', text)
                        if unicodedata.category(char) != 'Mn')  # Strip accents
         text = text.lower()
-        text = re.sub("[^ a-z'.,?!\-]", "", text)
+        text = re.sub(r"[^ a-z'.,?!\-]", "", text)
         text = text.replace("i.e.", "that is")
         text = text.replace("e.g.", "for example")
 


### PR DESCRIPTION
g2p_en の推論スクリプトに以下の変更を加えました。

- python 3.14 環境で codecs.open() の deprecated メッセージが出たため、encoding 指定のある open() に置き換えました。
- スクリプトがダウンロードする averaged_perceptron_tagger.pickle のロード方法を変更しました。
    - nltk 3.9 から pickle の読み込み制限が厳しくなり、また、pickle が python 2.x で作られたものらしく、nltk にロードさせる方法ではエラーが出るようになりました。問題となっている `__builtin__.set` のみを追加で許可する unpickler クラスを用意してロードするようにしました。
- regex のバックスラッシュで警告が出ていたため、raw string で regex を書くようにしました。