### PR TITLE
reduce demucs memory usage

### DIFF
--- a/audio_processing/demucs/demucs.py
+++ b/audio_processing/demucs/demucs.py
@@ -372,8 +372,14 @@ def main():
 
     # initialize
     if not args.onnx:
+        mem_mode = ailia.get_memory_mode(
+            reduce_constant=True,
+            ignore_input_with_initializer=True,
+            reduce_interstage=False,
+            reuse_interstage=True,
+        )
         nets = {
-            name: ailia.Net(model_files, weight_files, env_id=env_id)
+            name: ailia.Net(model_files, weight_files, env_id=env_id, memory_mode=mem_mode)
             for name, weight_files, model_files in zip(
                 model_info["sources"],
                 model_info["weight_files"],


### PR DESCRIPTION
audio_processing/demucs のメモリ使用量を抑制する PR です。

本 PR 適用前は Vulkan(FP32) 推論で 30GB 程度の VRAM を要求していたのが、8GB 未満で全体推論が完走するようになります。