### PR TITLE
reduce samurai memory usage

### DIFF
--- a/object_tracking/samurai/samurai.py
+++ b/object_tracking/samurai/samurai.py
@@ -1466,10 +1466,16 @@ def main():
 
     # initialize
     if not args.onnx:
-        backbone = ailia.Net(MODEL_BACKBONE_PATH, WEIGHT_BACKBONE_PATH, env_id=env_id)
-        sam_heads = ailia.Net(MODEL_SAM_PATH, WEIGHT_SAM_PATH, env_id=env_id)
-        memory_encoder = ailia.Net(MODEL_ENC_PATH, WEIGHT_ENC_PATH, env_id=env_id)
-        memory_attn = ailia.Net(MODEL_ATN_PATH, WEIGHT_ATN_PATH, env_id=env_id)
+        mem_mode = ailia.get_memory_mode(
+            reduce_constant=True,
+            ignore_input_with_initializer=True,
+            reduce_interstage=False,
+            reuse_interstage=True,
+        )
+        backbone = ailia.Net(MODEL_BACKBONE_PATH, WEIGHT_BACKBONE_PATH, env_id=env_id, memory_mode=mem_mode)
+        sam_heads = ailia.Net(MODEL_SAM_PATH, WEIGHT_SAM_PATH, env_id=env_id, memory_mode=mem_mode)
+        memory_encoder = ailia.Net(MODEL_ENC_PATH, WEIGHT_ENC_PATH, env_id=env_id, memory_mode=mem_mode)
+        memory_attn = ailia.Net(MODEL_ATN_PATH, WEIGHT_ATN_PATH, env_id=env_id, memory_mode=mem_mode)
     else:
         import onnxruntime
 


### PR DESCRIPTION
object_tracking/samurai のメモリ使用量が大きかったため #1918 を参考に、memory_mode の指定を追加しました。メモリ使用量の変化はおおよそ以下の通りです(CPU は htop、CUDA は nvidia-smi の表示を読んだもの)。

-    CPU： 12.5GB → 4GB
-    fp32 CUDA： 12.2GB → 4GB
-    fp16 CUDA： 6.9GB → 2.5GB
