### PR TITLE
Fix facemesh_v2 crash when multiple faces are detected

### DIFF
--- a/face_recognition/facemesh_v2/facemesh_v2.py
+++ b/face_recognition/facemesh_v2/facemesh_v2.py
@@ -276,14 +276,14 @@ def predict(models, img):
             center_x * im_w, center_y * im_h,
             rect_width * im_w, rect_height * im_h,
             angle)
-        img, roi, pad = preprocess(img, roi)
+        input, roi, pad = preprocess(img, roi)
 
         # feedforward
         net = models['net']
         if not args.onnx:
-            output = net.predict([img])
+            output = net.predict([input])
         else:
-            output = net.run(None, {'input_12': img})
+            output = net.run(None, {'input_12': input})
         landmark_tensors, presence_flag_tensors, _ = output
 
         norm_rect = ROI(


### PR DESCRIPTION
predict() overwrote the source image with the preprocessed tensor inside the per-face loop, so the second face failed with a shape unpack error in preprocess(). Keep the source image intact and use a separate variable for the network input.

<img width="1072" height="680" alt="スクリーンショット 2026-08-31 17 20 12" src="https://github.com/user-attachments/assets/8ded5f93-a227-4d61-8193-d88284de8f4b" />
